### PR TITLE
Added detailed version to notify about group changes

### DIFF
--- a/Permissions/Permissions/Private/Permissions.cpp
+++ b/Permissions/Permissions/Private/Permissions.cpp
@@ -30,10 +30,23 @@ struct PermissionGroupUpdatedCallback
 	std::function<void(const FString&, int)> callback;
 };
 
+struct PermissionGroupUpdatedDetailedCallback
+{
+	PermissionGroupUpdatedDetailedCallback(FString CallbackName, std::function<void(const FString&, int, const FString&, bool, bool, bool)> callback)
+		: SubscriberUID(std::move(CallbackName)),
+		callback(std::move(callback))
+	{
+	}
+
+	FString SubscriberUID;
+	std::function<void(const FString&, int, const FString&, bool, bool, bool)> callback;
+};
+
 namespace Permissions
 {
 #pragma region Subscribers
 	std::vector<std::shared_ptr<PermissionGroupUpdatedCallback>> permissionGroupUpdatedSubscribers;
+	std::vector<std::shared_ptr<PermissionGroupUpdatedDetailedCallback>> permissionGroupUpdatedDetailedSubscribers;
 
 	/// <summary>
 	/// Subscribes to the PermissionGroupUpdatedCallback
@@ -72,6 +85,45 @@ namespace Permissions
 			subscriber->callback(eos_id, tribeid);
 		}
 	}
+
+	/// <summary>
+	/// Subscribes to the PermissionGroupUpdatedDetailedCallback
+	/// 
+	/// CallbackName is a unique identifier for the subscriber to be able to unsubscribe using a combination of PluginName and ServerID is recommended
+	/// </summary>
+	/// <param name="CallbackName"></param>
+	/// <param name="callback"></param>
+	void SubscribePermissionGroupUpdatedDetailedCallback(FString CallbackName, const std::function<void(const FString&, int, const FString&, bool, bool, bool)>& callback)
+	{
+		permissionGroupUpdatedDetailedSubscribers.push_back(std::make_shared<PermissionGroupUpdatedDetailedCallback>(CallbackName, callback));
+	}
+
+	/// <summary>
+	/// Removes the subscriber from the list of detailed-subscribers
+	/// </summary>
+	/// <param name="CallbackName"></param>
+	void UnSubscribePermissionGroupUpdatedDetailedCallback(FString CallbackName)
+	{
+		auto iter = std::find_if(permissionGroupUpdatedDetailedSubscribers.begin(), permissionGroupUpdatedDetailedSubscribers.end(),
+			[&CallbackName](const std::shared_ptr<PermissionGroupUpdatedDetailedCallback>& data) -> bool {return data->SubscriberUID == CallbackName; });
+
+		if (iter != permissionGroupUpdatedDetailedSubscribers.end())
+			permissionGroupUpdatedDetailedSubscribers.erase(std::remove(permissionGroupUpdatedDetailedSubscribers.begin(), permissionGroupUpdatedDetailedSubscribers.end(), *iter), permissionGroupUpdatedDetailedSubscribers.end());
+	}
+
+	/// <summary>
+	/// Processes the list of detailed-subscribers and notifies them of the change
+	/// </summary>
+	/// <param name="eos_id"></param>
+	/// <param name="tribeid"></param>
+	void NotifySubscribersDetailed(const FString& eosId, int tribeId, const FString& groupChanged, bool bAddedGroup, bool bIsTimedGroup, bool bIsTribeGroup)
+	{
+		for (const auto& subscriber : permissionGroupUpdatedDetailedSubscribers)
+		{
+			subscriber->callback(eosId, tribeId, groupChanged, bAddedGroup, bIsTimedGroup, bIsTribeGroup);
+		}
+	}
+
 #pragma endregion Subscribers
 
 	std::vector<std::shared_ptr<PermissionCallback>> playerPermissionCallbacks;
@@ -235,6 +287,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddPlayerToGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
+		NotifySubscribersDetailed(eos_id, 0, group, true, false, false);
 		return returnvalue;
 	}
 
@@ -243,6 +296,7 @@ namespace Permissions
 		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->RemovePlayerFromGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
+		NotifySubscribersDetailed(eos_id, 0, group, true, false, false);
 		return returnvalue;
 	}
 
@@ -251,6 +305,7 @@ namespace Permissions
 		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->AddPlayerToTimedGroup(eos_id, group, secs, delaySecs);
 		NotifySubscribers(eos_id, 0);
+		NotifySubscribersDetailed(eos_id, 0, group, true, true, false);
 		return returnvalue;
 	}
 
@@ -258,6 +313,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemovePlayerFromTimedGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
+		NotifySubscribersDetailed(eos_id, 0, group, false, true, false);
 		return returnvalue;
 	}
 
@@ -265,6 +321,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddTribeToGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
+		NotifySubscribersDetailed(L"", tribeId, group, true, false, true);
 		return returnvalue;
 	}
 
@@ -272,6 +329,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemoveTribeFromGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
+		NotifySubscribersDetailed(L"", tribeId, group, false, false, true);
 		return returnvalue;
 	}
 
@@ -279,6 +337,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddTribeToTimedGroup(tribeId, group, secs, delaySecs);
 		NotifySubscribers(L"", tribeId);
+		NotifySubscribersDetailed(L"", tribeId, group, true, true, true);
 		return returnvalue;
 	}
 
@@ -286,6 +345,7 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemoveTribeFromTimedGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
+		NotifySubscribersDetailed(L"", tribeId, group, false, true, true);
 		return returnvalue;
 	}
 	

--- a/Permissions/Permissions/Private/Permissions.cpp
+++ b/Permissions/Permissions/Private/Permissions.cpp
@@ -291,7 +291,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddPlayerToGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
-		NotifySubscribersDetailed(eos_id, 0, group, true, false, false);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(eos_id, 0, group, true, false, false);
 		return returnvalue;
 	}
 
@@ -300,7 +301,8 @@ namespace Permissions
 		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->RemovePlayerFromGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
-		NotifySubscribersDetailed(eos_id, 0, group, true, false, false);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(eos_id, 0, group, false, false, false);
 		return returnvalue;
 	}
 
@@ -309,7 +311,8 @@ namespace Permissions
 		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->AddPlayerToTimedGroup(eos_id, group, secs, delaySecs);
 		NotifySubscribers(eos_id, 0);
-		NotifySubscribersDetailed(eos_id, 0, group, true, true, false);
+		if(!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(eos_id, 0, group, true, true, false);
 		return returnvalue;
 	}
 
@@ -317,7 +320,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemovePlayerFromTimedGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
-		NotifySubscribersDetailed(eos_id, 0, group, false, true, false);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(eos_id, 0, group, false, true, false);
 		return returnvalue;
 	}
 
@@ -325,7 +329,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddTribeToGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
-		NotifySubscribersDetailed(L"", tribeId, group, true, false, true);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(L"", tribeId, group, true, false, true);
 		return returnvalue;
 	}
 
@@ -333,7 +338,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemoveTribeFromGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
-		NotifySubscribersDetailed(L"", tribeId, group, false, false, true);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(L"", tribeId, group, false, false, true);
 		return returnvalue;
 	}
 
@@ -341,7 +347,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->AddTribeToTimedGroup(tribeId, group, secs, delaySecs);
 		NotifySubscribers(L"", tribeId);
-		NotifySubscribersDetailed(L"", tribeId, group, true, true, true);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(L"", tribeId, group, true, true, true);
 		return returnvalue;
 	}
 
@@ -349,7 +356,8 @@ namespace Permissions
 	{
 		auto returnvalue = database->RemoveTribeFromTimedGroup(tribeId, group);
 		NotifySubscribers(L"", tribeId);
-		NotifySubscribersDetailed(L"", tribeId, group, false, true, true);
+		if (!returnvalue.has_value()) // no error occured
+			NotifySubscribersDetailed(L"", tribeId, group, false, true, true);
 		return returnvalue;
 	}
 	

--- a/Permissions/Permissions/Private/Permissions.cpp
+++ b/Permissions/Permissions/Private/Permissions.cpp
@@ -298,7 +298,6 @@ namespace Permissions
 
 	std::optional<std::string> RemovePlayerFromGroup(const FString& eos_id, const FString& group)
 	{
-		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->RemovePlayerFromGroup(eos_id, group);
 		NotifySubscribers(eos_id, 0);
 		if (!returnvalue.has_value()) // no error occured
@@ -308,7 +307,6 @@ namespace Permissions
 
 	std::optional<std::string> AddPlayerToTimedGroup(const FString& eos_id, const FString& group, int secs, int delaySecs)
 	{
-		NotifySubscribers(eos_id, 0);
 		auto returnvalue = database->AddPlayerToTimedGroup(eos_id, group, secs, delaySecs);
 		NotifySubscribers(eos_id, 0);
 		if(!returnvalue.has_value()) // no error occured

--- a/Permissions/Permissions/Private/Permissions.cpp
+++ b/Permissions/Permissions/Private/Permissions.cpp
@@ -114,8 +114,12 @@ namespace Permissions
 	/// <summary>
 	/// Processes the list of detailed-subscribers and notifies them of the change
 	/// </summary>
-	/// <param name="eos_id"></param>
-	/// <param name="tribeid"></param>
+	/// <param name="eosId"></param>
+	/// <param name="tribeId"></param>
+	/// <param name="groupChanged"></param>
+	/// <param name="bAddedGroup"></param>
+	/// <param name="bIsTimedGroup"></param>
+	/// <param name="bIsTribeGroup"></param>
 	void NotifySubscribersDetailed(const FString& eosId, int tribeId, const FString& groupChanged, bool bAddedGroup, bool bIsTimedGroup, bool bIsTribeGroup)
 	{
 		for (const auto& subscriber : permissionGroupUpdatedDetailedSubscribers)

--- a/Permissions/Permissions/Public/Permissions.h
+++ b/Permissions/Permissions/Public/Permissions.h
@@ -47,4 +47,7 @@ namespace Permissions
 
 	PERMISSIONS_API void SubscribePermissionGroupUpdatedCallback(FString CallbackName, const std::function<void(const FString&, int)>& callback);
 	PERMISSIONS_API void UnSubscribePermissionGroupUpdatedCallback(FString CallbackName);
+
+	PERMISSIONS_API void SubscribePermissionGroupUpdatedDetailedCallback(FString CallbackName, const std::function<void(const FString&, int, const FString&, bool, bool, bool)>& callback);
+	PERMISSIONS_API void UnSubscribePermissionGroupUpdatedDetailedCallback(FString CallbackName);
 }


### PR DESCRIPTION
Added detailed version to notify about group changes with additional information without breaking existing plugins.

Use Case: A plugin wants to do something once when a player gains/loses a certain group, like grant some kind of reward. With the normal version you would need quite a lot of additional bookkeeping to check if the player gained/lost a certain group and did not have it before.

NotifySubscribers gets called twice in some functions, I don't really know why, but decided that this does not really make sense for the detailed version NotifySubscribersDetailed, because you really only want to be notified about a change once. So it always get called only once per change.

Does only get notified if the add/remove did not return an error message, like missing group, or player already in group.

I compiled the changes and tested them on a regular private server on a root server. Adding a group to a player who already has the group does not fire the detailed notify for example.
<img width="1585" height="259" alt="image" src="https://github.com/user-attachments/assets/7b7cb99c-33be-4e6d-b009-be2dff925735" />