### PR TITLE
feat(arkshop): add arkshoplogtransactions table and purchase logging

### DIFF
--- a/ArkShop/ArkShop/Private/ArkShop.cpp
+++ b/ArkShop/ArkShop/Private/ArkShop.cpp
@@ -724,7 +724,8 @@ void Load()
 				mysql_conf.value("MysqlPass", ""),
 				mysql_conf.value("MysqlDB", ""),
 				mysql_conf.value("MysqlPlayersTable", "ArkShopPlayers"),
-				mysql_conf.value("MysqlPort", 3306));
+				mysql_conf.value("MysqlPort", 3306),
+				mysql_conf.value("MysqlLogTable", "ArkShopLogTransactions"));
 		}
 		else
 		{

--- a/ArkShop/ArkShop/Private/Database/MysqlDB.h
+++ b/ArkShop/ArkShop/Private/Database/MysqlDB.h
@@ -7,8 +7,8 @@
 class MySql : public IDatabase
 {
 public:
-	explicit MySql(std::string server, std::string username, std::string password, std::string db_name, std::string table_players, const int port)
-		: table_players_(move(table_players))
+	explicit MySql(std::string server, std::string username, std::string password, std::string db_name, std::string table_players, const int port, std::string table_log)
+		: table_players_(move(table_players)), table_log_(move(table_log))
 	{
 		try
 		{
@@ -41,6 +41,22 @@ public:
 			if (!result)
 			{
 				Log::GetLog()->critical("({} {}) Failed to create table!", __FILE__, __FUNCTION__);
+			}
+
+			result = db_.query(fmt::format("CREATE TABLE IF NOT EXISTS {} ("
+				"Id INT NOT NULL AUTO_INCREMENT,"
+				"EosId VARCHAR(50) NOT NULL,"
+				"ItemName VARCHAR(255) NOT NULL,"
+				"ItemAmount INT DEFAULT 1,"
+				"TotalPrice INT DEFAULT 0,"
+				"ServersId VARCHAR(100) NOT NULL DEFAULT '',"
+				"BuyerDate DATETIME DEFAULT CURRENT_TIMESTAMP,"
+				"PRIMARY KEY(Id),"
+				"INDEX idx_eosid (EosId ASC));", table_log_));
+
+			if (!result)
+			{
+				Log::GetLog()->critical("({} {}) Failed to create log transactions table!", __FILE__, __FUNCTION__);
 			}
 		}
 		catch (const std::exception& exception)
@@ -226,7 +242,23 @@ public:
 		}
 	}
 
+	bool LogTransaction(const FString& eos_id, const std::string& item_name, int item_amount, int total_price, const std::string& server_id) override
+	{
+		try
+		{
+			return db_.query(fmt::format(
+				"INSERT INTO {} (EosId, ItemName, ItemAmount, TotalPrice, ServersId) VALUES ('{}', '{}', {}, {}, '{}');",
+				table_log_, eos_id.ToString(), item_name, item_amount, total_price, server_id));
+		}
+		catch (const std::exception& exception)
+		{
+			Log::GetLog()->error("({} {}) Unexpected DB error {}", __FILE__, __FUNCTION__, exception.what());
+			return false;
+		}
+	}
+
 private:
 	daotk::mysql::connection db_;
 	std::string table_players_;
+	std::string table_log_;
 };

--- a/ArkShop/Configs/config.json
+++ b/ArkShop/Configs/config.json
@@ -5,7 +5,9 @@
     "MysqlUser": "apitest",
     "MysqlPass": "12345",
     "MysqlDB": "apitest",
-    "MysqlPort": 3306
+    "MysqlPort": 3306,
+    "MysqlPlayersTable": "ArkShopPlayers",
+    "MysqlLogTable": "ArkShopLogTransactions"
   },
   "General": {
     "Discord": {


### PR DESCRIPTION
## What

Introduces a new `arkshoplogtransactions` table (MySQL and SQLite) that records every successful shop purchase. Each row stores the player's EosId, item identifier, quantity, total points spent, server/map ID, and a UTC timestamp.

## Why

There is currently no way to query shop purchase history from an external tool (e.g. a user panel or admin dashboard). Adding a dedicated log table makes this data available without parsing log files.

The table schema (`EosId`, `ItemName`, `ItemAmount`, `TotalPrice`, `ServersId`, `BuyerDate`) is designed to be consumed directly by user-panel APIs.

## Changes

- **`IDatabase.h`** — adds pure-virtual `LogTransaction()` to the interface
- **`MysqlDB.h`** — creates `arkshoplogtransactions` in the constructor (`IF NOT EXISTS`); implements `LogTransaction()` with `fmt::format`
- **`SqlLiteDB.h`** — same for SQLite, using prepared-statement `?` placeholders
- **`Store.cpp`** — calls `database->LogTransaction()` after every successful purchase

## How to Review

Start with `IDatabase.h` to see the new interface method, then follow the implementations in `MysqlDB.h` and `SqlLiteDB.h`. The call site is a single line added at the end of the `if (success)` block in `Store::Buy()`.

## Notes

- The table is created automatically on first run — no manual migration needed.
- The log write is best-effort: a failure does not affect the purchase outcome or roll it back.
- No existing behavior is changed.
- Sell transactions (`/sell`) are intentionally out of scope for this PR, but i can add them if needed.

Keep up the good work, i love your stuff.